### PR TITLE
ci: migrate GitHub Actions from Poetry to uv

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,7 +3,7 @@ name: CI
 on:
   push:
     paths:
-      - 'pycam/**'
+      - 'src/pycam/**'
       - 'app.py'
       - 'tests/**'
       - '.github/**'
@@ -13,10 +13,14 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v3
-      - uses: actions/setup-python@v4
+      - uses: actions/checkout@v4
+      - name: Install uv
+        uses: astral-sh/setup-uv@v6
         with:
-          python-version: '3.11'
-      - uses: snok/install-poetry@v1
-      - run: poetry install --no-interaction
-      - run: poetry run pytest
+          enable-cache: true
+      - name: Set up Python
+        run: uv python install
+      - name: Install dependencies
+        run: uv sync --all-extras
+      - name: Run tests
+        run: uv run pytest


### PR DESCRIPTION
## Summary

This PR updates the GitHub Actions CI workflow to use uv instead of Poetry, following the latest best practices for uv in CI/CD environments.

### Changes
- Replace Poetry setup (`snok/install-poetry@v1`) with `astral-sh/setup-uv@v6`
- Enable built-in caching for uv with `enable-cache: true`
- Use `uv python install` for automatic Python version detection based on project configuration
- Replace `poetry install` with `uv sync --all-extras` for dependency installation
- Replace `poetry run pytest` with `uv run pytest` for test execution
- Update path from `pycam/**` to `src/pycam/**` to match the src-layout migration
- Update `actions/checkout` from v3 to v4

### Test plan
- [x] CI workflow configuration updated
- [ ] Verify CI passes on GitHub Actions

This change aligns the CI workflow with the Poetry to uv migration completed in the previous PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)